### PR TITLE
We should be using OAuth1 access token, not request token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Next, add this line to your `app/build.gradle` file:
 
 ```gradle
 dependencies {
-    compile 'com.codepath.libraries:android-oauth-handler:1.1.2'
+    compile 'com.codepath.libraries:android-oauth-handler:1.1.3'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ ext {
 
     GROUP = 'com.codepath.libraries'
     BASE_VERSION = "1.2"
-    VERSION_NAME = "1.2.2"
+    VERSION_NAME = "1.2.3"
     POM_PACKAGING = "aar"
     POM_DESCRIPTION = "CodePath OAuth Handler"
 

--- a/app/src/main/java/com/codepath/oauth/OAuthBaseClient.java
+++ b/app/src/main/java/com/codepath/oauth/OAuthBaseClient.java
@@ -137,7 +137,7 @@ public abstract class OAuthBaseClient {
         int oAuthVersion = prefs.getInt(OAuthConstants.VERSION, 0);
 
         if (oAuthVersion == 1 && prefs.contains(OAuthConstants.TOKEN) && prefs.contains(OAuthConstants.TOKEN_SECRET)) {
-            return new OAuth1RequestToken(prefs.getString(OAuthConstants.TOKEN, ""),
+            return new OAuth1AccessToken(prefs.getString(OAuthConstants.TOKEN, ""),
                     prefs.getString(OAuthConstants.TOKEN_SECRET, ""));
         } else if (oAuthVersion == 2 && prefs.contains(OAuthConstants.TOKEN)) {
             return new OAuth2AccessToken(prefs.getString(OAuthConstants.TOKEN, ""));


### PR DESCRIPTION
Bug when retesting... using the wrong token type.

Also, any reason why we need to store the request token? (https://github.com/codepath/android-oauth-handler/blob/master/app/src/main/java/com/codepath/oauth/OAuthBaseClient.java#L58-L62).  
