### PR TITLE
adding in changes so that this will work with api 30

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -32,13 +32,13 @@ group = GROUP
 archivesBaseName = POM_ARTIFACT_ID
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         versionCode 1
         versionName VERSION_NAME
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
     }
 
     // Related to https://github.com/scribejava/scribejava/issues/480
@@ -90,18 +90,18 @@ ext {
 }
 
 dependencies {
-    api "androidx.appcompat:appcompat:1.0.2"
-    api 'com.codepath.libraries:asynchttpclient:0.0.8'
+    api "androidx.appcompat:appcompat:1.3.0"
+    api 'com.codepath.libraries:asynchttpclient:2.1.1'
     api 'com.github.scribejava:scribejava-apis:4.1.1'
     api 'com.github.scribejava:scribejava-httpclient-okhttp:4.1.1'
     implementation 'se.akerfeldt:okhttp-signpost:1.1.0'
     implementation 'oauth.signpost:signpost-core:1.2.1.2'
     implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
-    implementation "com.squareup.okhttp3:logging-interceptor:4.1.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.7.2"
 
 }
 
-/*task jar(type: Jar) {
+task jar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-}*/
+}

--- a/library/src/main/java/com/codepath/oauth/OAuthTokenClient.java
+++ b/library/src/main/java/com/codepath/oauth/OAuthTokenClient.java
@@ -34,12 +34,20 @@ public class OAuthTokenClient {
         this.apiInstance = apiInstance;
         this.handler = handler;
         if (callbackUrl == null) { callbackUrl = OAuthConstants.OUT_OF_BAND; };
-        this.service = new ServiceBuilder()
+        if(scope == null) {
+            this.service = new ServiceBuilder()
+                .apiKey(consumerKey)
+                .apiSecret(consumerSecret).callback(callbackUrl)
+                .httpClientConfig(OkHttpHttpClientConfig.defaultConfig())
+                .build(apiInstance);
+        } else {
+            this.service = new ServiceBuilder()
                 .apiKey(consumerKey)
                 .apiSecret(consumerSecret).callback(callbackUrl)
                 .httpClientConfig(OkHttpHttpClientConfig.defaultConfig())
                 .scope(scope) // OAuth2 requires scope
                 .build(apiInstance);
+        }
     }
 
     // Get a request token and the authorization url


### PR DESCRIPTION
These are some changes to allow the library to work when using a target sdk and compile sdk of 30 when running on Android 11. Before these changes you get an error because of an issue with okhttp which causes it to say that there is a min sdk of 21 but the target is 30, which is a known issue that was fixed with later versions. I left scribe at the older version because that was a much larger change, but updating asynchttpclient and logging-interceptor along with one small change to the TokenClient seemed to work even-though the dependencies the scribe okhttp are likely older (I'm guessing that they are segregated enough to not cause an issue).